### PR TITLE
Investigate and propose fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This flake provides Google Antigravity for NixOS systems with:
 - **FHS environment**: Standard Linux filesystem layout via `buildFHSEnv`
 - **Multi-platform support**: Linux (x86_64, aarch64) and macOS (x86_64, aarch64)
 - **Chrome integration**: Bundled wrapper for system Chrome with user profile support
+- **Chromium fallback**: Automatically uses Chromium on `aarch64-linux` where Google Chrome isn't available
 - **Version pinning**: Tagged releases for reproducible builds
 - **Zero configuration**: All dependencies included
 
@@ -167,6 +168,9 @@ Creates a Chrome wrapper that:
 
 - NixOS or Nix package manager with flakes enabled
 - `allowUnfree = true` in Nix configuration (Antigravity is proprietary software)
+- System browser:
+  - `x86_64-linux`: `google-chrome-stable`
+  - `aarch64-linux`: `chromium`
 
 ### Enabling Unfree Packages
 

--- a/package.nix
+++ b/package.nix
@@ -10,11 +10,11 @@
 , at-spi2-core
 , atk
 , cairo
+, chromium
 , cups
 , dbus
 , expat
 , glib
-, google-chrome
 , gtk3
 , libdrm
 , libgbm
@@ -29,22 +29,47 @@
 , systemd
 , xorg
 , zlib
+, google-chrome ? null
 }:
 
 let
   pname = "google-antigravity";
   version = "1.11.5-5234145629700096";
 
+  isAarch64 = stdenv.hostPlatform.system == "aarch64-linux";
+
+  browserPkg =
+    if isAarch64 then chromium
+    else if google-chrome != null then google-chrome
+    else throw ''
+      google-chrome is required on ${stdenv.hostPlatform.system} builds.
+      Make sure you have allowUnfree = true or pass a google-chrome package.
+    '';
+
+  browserCommand =
+    if isAarch64 then "chromium" else "google-chrome-stable";
+
+  browserProfileDir =
+    if isAarch64 then "$HOME/.config/chromium" else "$HOME/.config/google-chrome";
+
   src = fetchurl {
     url = "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/${version}/linux-x64/Antigravity.tar.gz";
     sha256 = "sha256-TgMVGlV0PPMPrFlauzQ8nrWjtqgNJUATbXW06tgHIRI=";
   };
 
-  # Create a Chrome wrapper that uses the user's existing profile
-  chrome-wrapper = writeShellScript "google-chrome-with-profile" ''
-    # Force Chrome to use user's existing profile where extension is installed
-    exec /run/current-system/sw/bin/google-chrome-stable \
-      --user-data-dir="$HOME/.config/google-chrome" \
+  # Create a browser wrapper that uses the user's existing profile
+  chrome-wrapper = writeShellScript "${browserCommand}-with-profile" ''
+    set -euo pipefail
+
+    system_browser="/run/current-system/sw/bin/${browserCommand}"
+    browser_cmd="$system_browser"
+
+    if [ ! -x "$system_browser" ]; then
+      browser_cmd=${browserPkg}/bin/${browserCommand}
+    fi
+
+    exec "$browser_cmd" \
+      --user-data-dir="${browserProfileDir}" \
       --profile-directory=Default \
       "$@"
   '';
@@ -80,47 +105,47 @@ let
   fhs = buildFHSEnv {
     name = "antigravity-fhs";
 
-    targetPkgs = pkgs: (with pkgs; [
-      alsa-lib
-      at-spi2-atk
-      at-spi2-core
-      atk
-      cairo
-      cups
-      dbus
-      expat
-      glib
-      google-chrome
-      gtk3
-      libdrm
-      libgbm
-      libglvnd
-      libnotify
-      libsecret
-      libuuid
-      libxkbcommon
-      mesa
-      nspr
-      nss
-      pango
-      stdenv.cc.cc.lib
-      systemd
-      vulkan-loader
-      xorg.libX11
-      xorg.libXScrnSaver
-      xorg.libXcomposite
-      xorg.libXcursor
-      xorg.libXdamage
-      xorg.libXext
-      xorg.libXfixes
-      xorg.libXi
-      xorg.libXrandr
-      xorg.libXrender
-      xorg.libXtst
-      xorg.libxcb
-      xorg.libxshmfence
-      zlib
-    ]);
+    targetPkgs = pkgs:
+      (with pkgs; [
+        alsa-lib
+        at-spi2-atk
+        at-spi2-core
+        atk
+        cairo
+        cups
+        dbus
+        expat
+        glib
+        gtk3
+        libdrm
+        libgbm
+        libglvnd
+        libnotify
+        libsecret
+        libuuid
+        libxkbcommon
+        mesa
+        nspr
+        nss
+        pango
+        stdenv.cc.cc.lib
+        systemd
+        vulkan-loader
+        xorg.libX11
+        xorg.libXScrnSaver
+        xorg.libXcomposite
+        xorg.libXcursor
+        xorg.libXdamage
+        xorg.libXext
+        xorg.libXfixes
+        xorg.libXi
+        xorg.libXrandr
+        xorg.libXrender
+        xorg.libXtst
+        xorg.libxcb
+        xorg.libxshmfence
+        zlib
+      ]) ++ lib.optional (browserPkg != null) browserPkg;
 
     runScript = writeShellScript "antigravity-wrapper" ''
       # Set Chrome paths to use our wrapper that forces user profile


### PR DESCRIPTION
Add platform-aware browser selection and fallback to fix build failures on `aarch64-linux` where Google Chrome is unavailable.

The original setup hardcoded `google-chrome`, which is not available on `aarch64-linux`, leading to build failures (as reported in https://github.com/jacopone/antigravity-nix/issues/1). This change introduces `chromium` as an alternative for `aarch64-linux` and makes the browser selection dynamic based on the host platform. It also ensures that if the system browser isn't found, the packaged one is used, maintaining user profile functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b76f7e9-c6a3-450e-b761-3340ecfe6566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5b76f7e9-c6a3-450e-b761-3340ecfe6566"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

