### PR TITLE
fix: make it work on wayland

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -163,7 +163,7 @@ let
     name = "antigravity";
     desktopName = "Google Antigravity";
     comment = "Next-generation agentic IDE";
-    exec = "antigravity %U";
+    exec = "antigravity --enable-features=UseOzonePlatform,WaylandWindowDecorations --ozone-platform-hint=auto %U";
     icon = "antigravity";
     categories = [ "Development" "IDE" ];
     startupNotify = true;


### PR DESCRIPTION
On my hyperland setup the applicaton is starting via xwayland. Can we include the wayland flags for electron?
Alternatively I could insert them via a package argument at the top of package.nix if you do not want to default to wayland.

Thanks for this amazing packaging btw!