### PR TITLE
fix: add xorg.libxkbfile dependency to resolve native-keymap runtime error

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -144,6 +144,7 @@ let
         xorg.libXtst
         xorg.libxcb
         xorg.libxshmfence
+        xorg.libxkbfile
         zlib
       ]) ++ lib.optional (browserPkg != null) browserPkg;
 


### PR DESCRIPTION
## Summary
This PR adds `xorg.libxkbfile` to the FHS environment dependencies.
It appears that Antigravity utilizes the `native-keymap` Electron module, which depends on `libxkbfile`. This is evidenced by the runtime error logs observed when the library is missing.

## Context & Bug Report
I ran the original flake using `nix run github:jacopone/antigravity-nix`.

**Behavior:**
1. The application **launched successfully** (GUI appeared).
2. However, the terminal logged the following error immediately:

```text
Error: Cannot find module './build/Debug/keymapping'
Require stack:
- .../node_modules/native-keymap/index.js
...
TypeError: Cannot read properties of null (reading 'getCurrentKeyboardLayout')
```

This error indicates that the `native-keymap` module failed to load due to the missing `libxkbfile.so` shared library. This suggests that keyboard mapping functionality (provided by this module) might be impaired, although I did not explicitly test the mapping behavior itself.

## Solution
Added `xorg.libxkbfile` to `package.nix` in the `targetPkgs` list.

## Verification
- **Build**: Ran `nix build .` successfully.
- **Runtime**: Validated by running the built binary `./result/bin/antigravity`.
- **Result**: The application launches, and the terminal log is now **clean** (no `native-keymap` errors), confirming that the dependency issue is resolved.

## Appendix: System Configuration
The issue was reproduced and fixed on the following system:
- **OS**: NixOS 26.05.20251202.418468a (Yarara)
- **Kernel**: Linux 6.12.60
- **Nix Version**: 2.31.2
- **Desktop Environment**: GNOME

---

#### 🇨🇳 中文说明 (Chinese Translation)

**摘要**
本 PR 向 FHS 环境依赖中添加了 `xorg.libxkbfile`。
从报错日志来看，Antigravity 似乎使用了 `native-keymap` Electron 模块，而该模块依赖此库。

**背景与排查**
我执行 `nix run github:jacopone/antigravity-nix` 启动应用。

**现象：**
1. 应用**成功启动**，GUI 界面正常弹出。
2. 但终端立即打印报错日志：`Error: Cannot find module './build/Debug/keymapping'...`。

这表明 `native-keymap` 模块因缺少 `libxkbfile.so` 而加载失败。这可能导致键盘映射功能失效（尽管我没有专门验证映射功能本身，只观察到报错）。

**验证**
- 在 `package.nix` 添加依赖后，重新构建并运行。
- **结果**：日志变干净了，不再有上述报错，证明依赖修复有效。

**附录：系统配置**
- **系统**: NixOS 26.05 (Unstable/Yarara)
- **桌面**: GNOME
- **内核**: 6.12.60
```