### PR TITLE
feat: update antigravity to 1.11.17

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,7 +53,7 @@
       }
     ) // {
       # Version information for auto-update
-      version = "1.11.14-5763785964257280";
+      version = "1.11.17-6639170008514560";
 
       # Overlay for easy integration into NixOS configurations
       overlays.default = final: prev: {

--- a/package.nix
+++ b/package.nix
@@ -34,7 +34,7 @@
 
 let
   pname = "google-antigravity";
-  version = "1.11.14-5763785964257280";
+  version = "1.11.17-6639170008514560";
 
   isAarch64 = stdenv.hostPlatform.system == "aarch64-linux";
 
@@ -54,7 +54,7 @@ let
 
   src = fetchurl {
     url = "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/${version}/linux-x64/Antigravity.tar.gz";
-    sha256 = "sha256-mDxHj03vM6aGI9wHoEFWQEwv4qzN1JK7LwZ+PZEjniA=";
+    sha256 = "sha256-RUh4n14wrRPvNB7xEvOjmbLWsODMlee/WgYlsIpacSA=";
   };
 
   # Create a browser wrapper that uses the user's existing profile


### PR DESCRIPTION
###### Note: This update works best with PR \#7 (libxkbfile fix) to avoid runtime log errors.

This PR updates Google Antigravity to the latest detected version `1.11.17`.

### Changes

  - Update version to `1.11.17`
  - Update SHA256 hash

Verified locally and via clean remote build.

### Security Verification

You can verify the SHA256 hash matches the official Google release artifact by running this command:

```bash
# Verify the upstream artifact matches the hash in this PR
nix hash to-sri --type sha256 $(nix-prefetch-url https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/1.11.17-6639170008514560/linux-x64/Antigravity.tar.gz)
# Expected output: sha256-RUh4n14wrRPvNB7xEvOjmbLWsODMlee/WgYlsIpacSA=
```

-----

###### 注意：此更新最好配合 PR \#7 (修复 libxkbfile) 以避免运行时的日志报错。

本 PR 将 Google Antigravity 更新至检测到的最新版本 `1.11.17`。

### 变更内容

  - 更新版本号至 `1.11.17`
  - 更新 SHA256 哈希值

已在本地及远程构建环境中通过验证。

### 安全验证 (Security Verification)

你可以运行以下命令来验证 SHA256 哈希值是否与 Google 官方发布的构建产物一致：

```bash
# 验证上游产物是否匹配本 PR 中的哈希值
nix hash to-sri --type sha256 $(nix-prefetch-url https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/1.11.17-6639170008514560/linux-x64/Antigravity.tar.gz)
# 预期输出: sha256-RUh4n14wrRPvNB7xEvOjmbLWsODMlee/WgYlsIpacSA=
```