### PR TITLE
fix: use CLI wrapper for proper forking behavior

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -154,7 +154,7 @@ let
       export CHROME_BIN=${chrome-wrapper}
       export CHROME_PATH=${chrome-wrapper}
 
-      exec ${antigravity-unwrapped}/lib/antigravity/antigravity "$@"
+      exec ${antigravity-unwrapped}/lib/antigravity/bin/antigravity "$@"
     '';
 
     meta = antigravity-unwrapped.meta;


### PR DESCRIPTION
## Summary
- Changed wrapper to call `bin/antigravity` (CLI script) instead of `antigravity` (Electron binary)
- Fixes desktop launcher not working and terminal blocking when run without arguments

The CLI script uses `ELECTRON_RUN_AS_NODE` to run `cli.js`, which forks properly - matching VS Code's behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)