### PR TITLE
fix: replace deprecated xorg.* package names

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -27,7 +27,20 @@
 , nss
 , pango
 , systemd
-, xorg
+, libx11
+, libxscrnsaver
+, libxcomposite
+, libxcursor
+, libxdamage
+, libxext
+, libxfixes
+, libxi
+, libxrandr
+, libxrender
+, libxtst
+, libxcb
+, libxshmfence
+, libxkbfile
 , zlib
 , google-chrome ? null
 }:
@@ -131,20 +144,20 @@ let
         stdenv.cc.cc.lib
         systemd
         vulkan-loader
-        xorg.libX11
-        xorg.libXScrnSaver
-        xorg.libXcomposite
-        xorg.libXcursor
-        xorg.libXdamage
-        xorg.libXext
-        xorg.libXfixes
-        xorg.libXi
-        xorg.libXrandr
-        xorg.libXrender
-        xorg.libXtst
-        xorg.libxcb
-        xorg.libxshmfence
-        xorg.libxkbfile
+        libx11
+        libxscrnsaver
+        libxcomposite
+        libxcursor
+        libxdamage
+        libxext
+        libxfixes
+        libxi
+        libxrandr
+        libxrender
+        libxtst
+        libxcb
+        libxshmfence
+        libxkbfile
         zlib
       ]) ++ lib.optional (browserPkg != null) browserPkg;
 


### PR DESCRIPTION
The `xorg` package set has been deprecated in nixpkgs 26.05. All
  `xorg.*` references now emit evaluation warnings:

  ```
  evaluation warning: The xorg package set has been deprecated, 'xorg.libX11' has been
  renamed to 'libx11'
  ```

  This PR replaces the 14 deprecated `xorg.*` references in `package.nix` with their
   new top-level names (e.g. `libx11`, `libxext`, `libxcb`, etc.).