### PR TITLE
feat: add Chrome profile isolation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ Or via override:
 google-antigravity.override { useFHS = false; }
 ```
 
+### Chrome Profile Isolation
+
+By default, Antigravity uses your system Chrome profile (`~/.config/google-chrome`), giving it access to your installed extensions. To run with an isolated Chrome profile instead (e.g., when testing untrusted apps):
+
+```nix
+google-antigravity.override { useSystemChromeProfile = false; }
+```
+
+This omits the `--user-data-dir` and `--profile-directory` flags, letting Chrome manage its own profile independently. Works with both FHS and non-FHS variants.
+
 ## Usage
 
 ```bash

--- a/package.nix
+++ b/package.nix
@@ -46,6 +46,7 @@
 , libxkbfile
 , zlib
 , useFHS ? true
+, useSystemChromeProfile ? true
 , google-chrome ? null
 }:
 
@@ -74,7 +75,11 @@ let
     sha256 = "sha256-TH/kjJVOTSVcXT6kx08Wikpxh/0r7tsiNCPLV0gcljg=";
   };
 
-  # Create a browser wrapper that uses the user's existing profile
+  # Create a browser wrapper
+  # When useSystemChromeProfile is true (default), forces use of the user's
+  # existing Chrome profile so extensions are available to Antigravity.
+  # When false, omits profile flags so Chrome runs with its own default
+  # behavior, isolating Antigravity from the user's main profile.
   chrome-wrapper = writeShellScript "${browserCommand}-with-profile" ''
     set -euo pipefail
 
@@ -86,8 +91,7 @@ let
     fi
 
     exec "$browser_cmd" \
-      --user-data-dir="${browserProfileDir}" \
-      --profile-directory=Default \
+      ${lib.optionalString useSystemChromeProfile ''--user-data-dir="${browserProfileDir}" --profile-directory=Default''} \
       "$@"
   '';
 


### PR DESCRIPTION
## Summary

- Adds `useSystemChromeProfile` parameter (default: `true`) to control whether Antigravity uses the user's existing Chrome profile
- When `false`, omits `--user-data-dir` and `--profile-directory` flags from the Chrome wrapper, letting Chrome manage its own profile independently
- Documents the option in README under "Chrome Profile Isolation"

## Usage

```nix
# Isolated Chrome profile (for testing untrusted apps)
google-antigravity.override { useSystemChromeProfile = false; }
```

Works with both FHS and non-FHS variants since both share the same `chrome-wrapper`.

Closes #18

## Test plan

- [x] `nix build .#default` — default behavior unchanged
- [x] `nix build` with `useSystemChromeProfile = false` — builds, wrapper omits profile flags
- [x] `nix flake check` — clean evaluation
- [x] Verified wrapper script content for both modes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)