### PR TITLE
feat: add srcOverride parameter for local tarball builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,23 @@ nix flake update antigravity-nix
 
 All releases: https://github.com/jacopone/antigravity-nix/releases
 
+## Troubleshooting
+
+### `fetchurl` fails or hash mismatches
+
+If the default `fetchurl` path fails — Google CDN unreachable, regional restrictions, hash drift after an upstream republish, corporate firewall — you can supply the tarball locally via `srcOverride`:
+
+1. Download `Antigravity.tar.gz` from https://antigravity.google/download/linux
+2. Point the package at it:
+
+```nix
+(antigravity-nix.packages.${system}.default.override {
+  srcOverride = /absolute/path/to/Antigravity.tar.gz;
+})
+```
+
+This bypasses `fetchurl` while keeping the rest of the packaging (FHS wrapping, Chrome integration, desktop entry) intact. No `--impure` and no patching `package.nix` required. Works for both the `default` and `google-antigravity-no-fhs` variants.
+
 ## Requirements
 
 - Nix with flakes enabled

--- a/package.nix
+++ b/package.nix
@@ -52,6 +52,7 @@
   useSystemChromeProfile ? true,
   google-chrome ? null,
   extraBwrapArgs ? [],
+  srcOverride ? null,
 }: let
   pname = "google-antigravity";
   version = "1.23.2-4781536860569600";
@@ -79,10 +80,14 @@
     then "$HOME/.config/chromium"
     else "$HOME/.config/google-chrome";
 
-  src = fetchurl {
-    url = "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/${version}/linux-x64/Antigravity.tar.gz";
-    sha256 = "sha256-UjKkBI/0+hVoXZqYG6T7pXPil/PvybdvY455S693VyU=";
-  };
+  finalSrc =
+    if srcOverride != null
+    then srcOverride
+    else
+      fetchurl {
+        url = "https://edgedl.me.gvt1.com/edgedl/release2/j0qc3/antigravity/stable/${version}/linux-x64/Antigravity.tar.gz";
+        sha256 = "sha256-UjKkBI/0+hVoXZqYG6T7pXPil/PvybdvY455S693VyU=";
+      };
 
   # Create a browser wrapper
   # When useSystemChromeProfile is true (default), forces use of the user's
@@ -179,7 +184,8 @@
 
   # Extract the upstream tarball without modification
   antigravity-unwrapped = stdenv.mkDerivation {
-    inherit pname version src;
+    inherit pname version;
+    src = finalSrc;
 
     dontBuild = true;
     dontConfigure = true;
@@ -280,7 +286,8 @@
   # in the integrated terminal.
 
   no-fhs-package = stdenv.mkDerivation {
-    inherit pname version src meta;
+    inherit pname version meta;
+    src = finalSrc;
 
     nativeBuildInputs = [
       autoPatchelfHook


### PR DESCRIPTION
## Summary
- Adds optional `srcOverride` parameter to `package.nix` so users can supply a local Antigravity tarball through the standard `callPackage` / `.override` interface — no `--impure` and no patching `package.nix` required.
- Default behavior is unchanged: omitting `srcOverride` still fetches from the Google CDN via `fetchurl`.
- Addresses a workaround reported by `@x_init0` on Twitter (manual download + `nix-store --add` + editing `package.nix` to use `builtins.path` + `nix run . --impure`).

## Usage
```nix
(antigravity-nix.packages.${system}.default.override {
  srcOverride = /path/to/Antigravity.tar.gz;
})
```

## Why `srcOverride` and not `src`
`pkgs.src` is a deprecation throw in current nixpkgs (`"renamed to simple-revision-control"`, added 2025-11-19). `callPackage` uses `intersectAttrs` to auto-fill any function parameter that matches a nixpkgs attribute *before* the function's default value applies, so a parameter literally named `src` triggers the throw on strict evaluation. `srcOverride` sidesteps the collision while keeping the override flow idiomatic.

## Test plan
- [x] `nix flake check` passes
- [x] `nix build .#default` builds (uses `fetchurl` default)
- [x] `nix build .#google-antigravity-no-fhs` builds (uses `fetchurl` default)
- [x] Override produces a different `drvPath` than default (confirms the conditional branch is reachable)
- [ ] Manual: end-to-end build using `srcOverride` with a real local tarball
- [ ] Manual: end-to-end runtime smoke test on NixOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)