### PR TITLE
fix: detect merged PRs via API instead of git ancestry

### DIFF
--- a/.github/workflows/cleanup-branches.yml
+++ b/.github/workflows/cleanup-branches.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read
 
 jobs:
   cleanup-pr-branch:
@@ -55,11 +56,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0  # Fetch all history for all branches
-
       - name: Find and delete stale auto-update branches
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -86,9 +82,10 @@ jobs:
             echo ""
             echo "Checking branch: $BRANCH"
 
-            # Check if branch is merged into master
-            if git merge-base --is-ancestor "origin/$BRANCH" origin/master 2>/dev/null; then
-              echo "  ✓ Branch is merged into master"
+            # Check via PR API (handles squash, rebase, and merge-commit strategies)
+            MERGED_PR=$(gh pr list --repo "$REPO" --head "$BRANCH" --state merged --json number --jq '.[0].number')
+            if [ -n "$MERGED_PR" ]; then
+              echo "  ✓ PR #$MERGED_PR was merged"
 
               if [ "$DRY_RUN" = "true" ]; then
                 echo "  [DRY RUN] Would delete: $BRANCH"
@@ -103,7 +100,7 @@ jobs:
                 fi
               fi
             else
-              echo "  ⊘ Branch not merged yet, keeping it"
+              echo "  ⊘ No merged PR found for this branch, keeping it"
               SKIPPED=$((SKIPPED + 1))
             fi
 


### PR DESCRIPTION
## Summary

The weekly cleanup workflow has been silently broken since this repo started squash-merging auto-update PRs. Every scheduled run reports `Deleted: 0, Skipped: N` because `git merge-base --is-ancestor` can't recognize squash merges (the squashed commit on master is a brand-new SHA, so the branch tip is never an ancestor of master).

Currently 4 stale `auto-update/*` branches exist for already-merged PRs (#37–#40).

## Changes

- Replace `git merge-base --is-ancestor` with `gh pr list --state merged --head $BRANCH` — uses GitHub's PR record as ground truth, works for squash, rebase, and merge-commit strategies alike.
- Add `pull-requests: read` permission (required by `gh pr list` when an explicit `permissions:` block is present, since unlisted scopes default to `none`).
- Remove the now-unused `actions/checkout` step (the new logic doesn't need git history).

## Test plan

- [x] YAML parses cleanly (`python3 -c 'import yaml; yaml.safe_load(...)'`)
- [x] Local sanity check: `gh pr list --head auto-update/antigravity-1.23.2-... --state merged` returns `40` (PR #40 was the merged PR for that branch)
- [x] Local sanity check: same query against a nonexistent branch returns empty (won't trigger deletion)
- [ ] After merge: trigger workflow manually with `dry_run=false` to clean up the 4 stale branches and verify the new logic on real data

🤖 Generated with [Claude Code](https://claude.com/claude-code)