### PR TITLE
fix: drop ill-defined \/ escapes in package.nix version matcher

### DIFF
--- a/pkgs/package.nix
+++ b/pkgs/package.nix
@@ -72,7 +72,7 @@ let
 
   version =
     let
-      match = builtins.match ".*\/([0-9]+\\.[0-9]+\\.[0-9]+-[0-9]+)\/.*" finalUrl;
+      match = builtins.match ".*/([0-9]+\\.[0-9]+\\.[0-9]+-[0-9]+)/.*" finalUrl;
     in
     if match != null then builtins.elemAt match 0 else "unknown";
 


### PR DESCRIPTION
Fixes #78.

`"\/"` is not a defined escape in the Nix string grammar. It happens to evaluate to `/`, so the regex behaves correctly, but Lix emits a deprecation warning on every evaluation of the flake:

```
warning: \/ is an ill-defined escape. You can drop the \ and simply write / instead.
         at .../pkgs/package.nix:75:34:
             74|     let
             75|       match = builtins.match ".*\/([0-9]+\\.[0-9]+\\.[0-9]+-[0-9]+)\/.*" finalUrl;
               |                                  ^
```

This writes both slashes literally. The `\\.` escapes are left alone — those are real, producing the literal `\.` the regex needs to match a dot rather than any character.

## Verification

The change is provably behaviour-preserving; the two literals are the same string:

```
$ nix eval --expr '".*\/([0-9]+\\.[0-9]+\\.[0-9]+-[0-9]+)\/.*" == ".*/([0-9]+\\.[0-9]+\\.[0-9]+-[0-9]+)/.*"'
true
```

All six flake outputs still evaluate with the versions from #77 intact:

```
$ nix eval --json '.#packages.x86_64-linux' --apply 'ps: builtins.mapAttrs (n: p: p.version) ps'
{"default":"2.0.0-6324554176528384",
 "google-antigravity":"2.0.0-6324554176528384",
 "google-antigravity-cli":"1.1.11-4956531888881664",
 "google-antigravity-ide":"2.1.1-6123990880747520",
 "google-antigravity-ide-no-fhs":"2.1.1-6123990880747520",
 "google-antigravity-no-fhs":"2.0.0-6324554176528384"}
```

`grep -rn '\\/' --include='*.nix' .` confirms line 75 was the only such escape in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)