### PR TITLE
fix: launch the IDE via its bundled CLI launcher so it detaches

### DIFF
--- a/pkgs/package.nix
+++ b/pkgs/package.nix
@@ -78,7 +78,13 @@ let
 
   pname = if isIde then "google-antigravity-ide" else "google-antigravity2";
   desktopName = if isIde then "Google Antigravity IDE" else "Google Antigravity";
-  binaryRelPath = if isIde then "antigravity-ide" else "antigravity";
+  # For the IDE, launch through the bundled CLI launcher (bin/antigravity-ide)
+  # rather than the top-level Electron binary. The launcher runs the app via
+  # resources/app/out/cli.js, which hands the arguments to a running or newly
+  # spawned detached window and returns, so `antigravity-ide <FOLDER>` gives the
+  # shell back instead of blocking it (v1 behaviour; see issue #55). The base app
+  # tarball ships no bin/ launcher and no cli.js, so it keeps exec'ing its binary.
+  binaryRelPath = if isIde then "bin/antigravity-ide" else "antigravity";
   desktopIcon = if isIde then "antigravity-ide" else "antigravity";
   startupWMClass = if isIde then "Antigravity IDE" else "Antigravity";
 


### PR DESCRIPTION
Fixes #55.

## Problem

The IDE wrapper exec'd the top-level Electron binary (`antigravity-ide`) directly. That binary is the app's main process, so `antigravity-ide <FOLDER>` held the terminal for the entire lifetime of the window — a regression from v1, where the command returned immediately.

## Fix

Point `binaryRelPath` at the bundled CLI launcher, `bin/antigravity-ide`. It is the standard VS Code launcher script and ends with:

```sh
ELECTRON="$VSCODE_PATH/antigravity-ide"
CLI="$VSCODE_PATH/resources/app/out/cli.js"
ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" "$@"
```

`cli.js` hands the arguments to a running or newly spawned detached window and exits, so the shell comes straight back.

The launcher resolves `VSCODE_PATH` from `$0` (`dirname "$0"/..` when `$0` is not a symlink). Our wrapper invokes it by its real store path, so it correctly finds `antigravity-ide` and `resources/app/out/cli.js` one level up. This covers both consumers of `binaryRelPath` — the FHS `runScript` and the no-FHS `makeWrapper --add-flags`.

## Verification

Contents confirmed in the IDE 2.1.1 tarball currently pinned in `artifacts/versions.json` (fetched hash matches the pinned `sha256-Wyzr99M6aNAD/Y8fqYjRYAkFrOIlBKCF5ThCFCkIeL0=`):

```
Antigravity IDE/antigravity-ide            <- Electron binary (old target)
Antigravity IDE/bin/antigravity-ide        <- CLI launcher (new target)
Antigravity IDE/resources/app/out/cli.js
```

Behaviour, before and after, using `--version` as a proxy for "does the command return":

| | result |
|---|---|
| master (`antigravity-ide`) | flag ignored, booted the full app (onboarding server, window), **never returned** — killed at 25s, exit 124 |
| this PR (`bin/antigravity-ide`) | printed `1.107.0` / commit / `x64`, **exit 0 immediately** |

`nix build .#google-antigravity-ide` succeeds.

## Scope

Deliberately IDE-only. The base app tarball contains just `Antigravity-x64/antigravity` — no `bin/` launcher and no `cli.js` — so it keeps exec'ing its Electron binary directly.

## One thing worth a look

The `.desktop` entry (`exec = "antigravity-ide %U"`) now also goes through the launcher, which exits as soon as the detached window is spawned. The app still opens, but `StartupNotify=true` may no longer pair with a process the desktop environment can track. Happy to route the desktop entry at the Electron binary directly and keep the launcher for the terminal path if you'd prefer to be conservative there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)