### PR TITLE
fix: use new hub endpoint for Base App version checks

### DIFF
--- a/artifacts/versions.json
+++ b/artifacts/versions.json
@@ -1,20 +1,20 @@
 {
   "Antigravity 2.0": {
     "x86_64-linux": {
-      "url": "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.0.0-6324554176528384/linux-x64/Antigravity.tar.gz",
-      "hash": "sha256-FLyctIClvo+zt9w+Kwzr+mbTcK1YzB4PoBFA0SBNQpc="
+      "url": "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.8.1-6512087774658560/linux-x64/Antigravity.tar.gz",
+      "hash": "sha256-I/bDv+8rMyb4t0fNnhW6NAHHAigENuTgO5qGPGZ47/M="
     },
     "aarch64-linux": {
-      "url": "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.0.0-6324554176528384/linux-arm/Antigravity.tar.gz",
-      "hash": "sha256-Qt9fSfwg2p3weW5/aJENqGh/Awr1PY2ISgp/oiiFceA="
+      "url": "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.8.1-6512087774658560/linux-arm/Antigravity.tar.gz",
+      "hash": "sha256-1HGxw0K+MZXHfdIN590sV0YqB2rOvfmuoSuRarK9Mmw="
     },
     "x86_64-darwin": {
-      "url": "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.0.0-6324554176528384/darwin-x64/Antigravity.dmg",
-      "hash": "sha256-dBZWG4GGZlZFPVGBD/ZMGb/cQbX6vKLKJT6fg157IKY="
+      "url": "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.8.1-6512087774658560/darwin-x64/Antigravity.dmg",
+      "hash": "sha256-DHWLzQ3LnnT40hErSsdtjXtQKWPqUJQ9MVs2KPl6I6c="
     },
     "aarch64-darwin": {
-      "url": "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.0.0-6324554176528384/darwin-arm/Antigravity.dmg",
-      "hash": "sha256-+Ww2C+DcQZGG+Ycnawqh+MIt7xt27sCJJTfBk+a/T90="
+      "url": "https://storage.googleapis.com/antigravity-public/antigravity-hub/2.8.1-6512087774658560/darwin-arm/Antigravity.dmg",
+      "hash": "sha256-RXtuahyTi2GzTtwjKNEaLyxVP7v15PxBP5FuyFNXOWU="
     }
   },
   "Antigravity IDE": {

--- a/scripts/check-version.sh
+++ b/scripts/check-version.sh
@@ -58,6 +58,6 @@ check_app() {
 	echo ""
 }
 
-check_app "Antigravity 2.0" "https://antigravity-auto-updater-974169037036.us-central1.run.app/releases"
+check_app "Antigravity 2.0" "https://antigravity-hub-auto-updater-974169037036.us-central1.run.app/releases"
 check_app "Antigravity CLI" "https://antigravity-cli-auto-updater-974169037036.us-central1.run.app/manifests/linux_amd64.json"
 check_app "Antigravity IDE" "https://antigravity-ide-auto-updater-974169037036.us-central1.run.app/releases"

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -16,7 +16,7 @@ if [[ ! -f "$OUTPUT_JSON" ]]; then
 fi
 
 log_info "Fetching IDE/App latest versions..."
-APP_VER=$(curl -sL "https://antigravity-auto-updater-974169037036.us-central1.run.app/releases" | jq -r '.[0] | .version + "-" + .execution_id')
+APP_VER=$(curl -sL "https://antigravity-hub-auto-updater-974169037036.us-central1.run.app/releases" | jq -r '.[0] | .version + "-" + .execution_id')
 IDE_VER=$(curl -sL "https://antigravity-ide-auto-updater-974169037036.us-central1.run.app/releases" | jq -r '.[0] | .version + "-" + .execution_id')
 
 if [[ -z "$APP_VER" || "$APP_VER" == "null-null" ]]; then log_error "Failed to fetch App version"; exit 1; fi


### PR DESCRIPTION
## Summary

Google moved the Base App version API from `antigravity-auto-updater-*.run.app` to `antigravity-hub-auto-updater-*.run.app`. The old endpoint still responds HTTP 200 but serves a frozen release list (`2.0.0-6324554176528384`), so the daily update workflow silently concluded there was no app update — while the IDE and CLI (whose endpoints did not move) kept updating normally. This is why the packaged Base App has been stuck at 2.0.0 since June.

- Point `scripts/check-version.sh` and `scripts/update-version.sh` at the new `-hub-` endpoint (2 lines)
- Bump the Base App to `2.8.1-6512087774658560` in `artifacts/versions.json` via `./scripts/update-version.sh` (all four platforms, SRI hashes from `nix-prefetch-url`)

Closes #84. Supersedes #85 — the endpoint fix there is correct, but that PR is filed from a long-diverged fork master and cannot merge cleanly; the fix is credited to @Daniel-42-z via Co-authored-by.

## Verification

- Old endpoint queried live: returns `2.0.0-6324554176528384` (the stale version)
- New endpoint queried live: returns `2.8.1-6512087774658560`
- `nix build .#default` succeeds with the new hashes
- `nix flake check` passes
- The built 2.8.1 app boots (Electron main process starts; note `--version` no longer prints-and-exits in 2.8.1, it launches the GUI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)