### PR TITLE
fix(darwin): moved from undmg to _7zz, locate .app bundles dynamically

### DIFF
--- a/pkgs/package.nix
+++ b/pkgs/package.nix
@@ -49,7 +49,7 @@
   libxshmfence,
   libxkbfile,
   zlib,
-  undmg,
+  _7zz,
   appType,
   useFHS ? true,
   useSystemChromeProfile ? true,
@@ -455,7 +455,7 @@ let
     inherit pname version meta;
     src = finalSrc;
 
-    nativeBuildInputs = [ undmg ];
+    nativeBuildInputs = [ _7zz ];
 
     sourceRoot = ".";
 
@@ -463,7 +463,13 @@ let
       runHook preInstall
 
       mkdir -p $out/Applications
-      cp -r *.app $out/Applications/
+
+      appDir=$(find . -mindepth 1 -maxdepth 3 -type d -name "*.app" | head -n 1)
+      if [ -z "$appDir" ]; then
+        echo "error: no .app bundle found in extracted DMG" >&2
+        exit 1
+      fi
+      cp -r "$appDir" $out/Applications/
 
       runHook postInstall
     '';

--- a/pkgs/package.nix
+++ b/pkgs/package.nix
@@ -50,6 +50,7 @@
   libxkbfile,
   zlib,
   _7zz,
+  darwin,
   appType,
   useFHS ? true,
   useSystemChromeProfile ? true,
@@ -455,21 +456,35 @@ let
     inherit pname version meta;
     src = finalSrc;
 
-    nativeBuildInputs = [ _7zz ];
+    nativeBuildInputs = [
+      _7zz
+      darwin.sigtool
+    ];
 
     sourceRoot = ".";
+
+    dontFixup = true;
 
     installPhase = ''
       runHook preInstall
 
       mkdir -p $out/Applications
 
-      appDir=$(find . -mindepth 1 -maxdepth 3 -type d -name "*.app" | head -n 1)
-      if [ -z "$appDir" ]; then
-        echo "error: no .app bundle found in extracted DMG" >&2
+      shopt -s nullglob
+      apps=( ./*.app ./*/*.app )
+      if [ ''${#apps[@]} -ne 1 ]; then
+        echo "error: expected exactly one .app bundle in DMG, found ''${#apps[@]}: ''${apps[*]}" >&2
         exit 1
       fi
+      appDir="''${apps[0]}"
       cp -r "$appDir" $out/Applications/
+
+      destApp="$out/Applications/$(basename "$appDir")"
+      for exe in "$destApp"/Contents/MacOS/*; do
+        if [ -f "$exe" ] && [ -x "$exe" ]; then
+          codesign --force --sign - "$exe"
+        fi
+      done
 
       runHook postInstall
     '';


### PR DESCRIPTION
undmg no longer works with the latest build.
```sh
nix log /nix/store/p60zq1691s0aiydlxwxvq241l7nlc9mn-google-antigravity2-2.9.1-4871453687021568.drv

Running phase: unpackPhase

@nix { "action": "setPhase", "phase": "unpackPhase" }

unpacking source archive /nix/store/jjwmizxz5z49gpray7kxwx270781nqpw-Antigravity.dmg

error: only HFS file systems are supported.

do not know how to unpack source archive /nix/store/jjwmizxz5z49gpray7kxwx270781nqpw-Antigravity.dmg
```
Switched to using 7zz but it may extract DMG contents into a subfolder named after the volume so now the config is locating the .app bundle rather than assuming top level.