### PR TITLE
Add libpulseaudio to dlopenLibs and ALSA_PLUGIN_DIR for PipeWire audio

### DIFF
--- a/pkgs/package.nix
+++ b/pkgs/package.nix
@@ -298,6 +298,12 @@ let
       export CHROME_BIN=${chrome-wrapper}
       export CHROME_PATH=${chrome-wrapper}
 
+      # Fallback for ALSA plugin discovery. On NixOS with
+      # services.pipewire.alsa.enable, /etc/alsa/conf.d already points
+      # alsa-lib at the plugin by absolute path and this is unused; it only
+      # matters where that config is absent. Never overrides an existing value.
+      export ALSA_PLUGIN_DIR="''${ALSA_PLUGIN_DIR:-${pipewire}/lib/alsa-lib}"
+
       exec ${antigravity-unwrapped}/lib/${pname}/${binaryRelPath} ${lib.optionalString isIde "--user-data-dir=$HOME/.antigravity-ide"} "$@"
     '';
 
@@ -434,7 +440,7 @@ let
         --set CHROME_BIN ${chrome-wrapper} \
         --set CHROME_PATH ${chrome-wrapper} \
         --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath dlopenLibs}" \
-        --set ALSA_PLUGIN_DIR "${pipewire}/lib/alsa-lib" \
+        --set-default ALSA_PLUGIN_DIR "${pipewire}/lib/alsa-lib" \
         --prefix XDG_DATA_DIRS : "${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}"
 
       # Install icon from the app resources

--- a/pkgs/package.nix
+++ b/pkgs/package.nix
@@ -26,6 +26,8 @@
   libgbm,
   libglvnd,
   libnotify,
+  libpulseaudio,
+  pipewire,
   libsecret,
   libuuid,
   libxkbcommon,
@@ -137,6 +139,7 @@ let
     systemdLibs
     libnotify
     libsecret
+    libpulseaudio
   ];
 
   # Libraries linked normally (resolved by autoPatchelf via rpath)
@@ -431,6 +434,7 @@ let
         --set CHROME_BIN ${chrome-wrapper} \
         --set CHROME_PATH ${chrome-wrapper} \
         --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath dlopenLibs}" \
+        --set ALSA_PLUGIN_DIR "${pipewire}/lib/alsa-lib" \
         --prefix XDG_DATA_DIRS : "${gsettings-desktop-schemas}/share/gsettings-schemas/${gsettings-desktop-schemas.name}:${gtk3}/share/gsettings-schemas/${gtk3.name}"
 
       # Install icon from the app resources


### PR DESCRIPTION
Chromium dlopens libpulse.so.0 at runtime (not DT_NEEDED, so autoPatchelfHook misses it in linkedLibs). When it fails, it falls back to ALSA, which also fails because ALSA_PLUGIN_DIR is not set to the PipeWire PCM plugin path.

This adds libpulseaudio to the existing dlopenLibs list (which feeds runtimeDependencies for autoPatchelf RPATH and the LD_LIBRARY_PATH wrapper), and sets ALSA_PLUGIN_DIR to pipewire's alsa-lib directory in the launcher wrapper.

Fixes in-app audio capture (getUserMedia, MediaRecorder) on PipeWire systems.

Tested on NixOS 26.11 with PipeWire: audio capture connects to PipeWire-Pulse after this change.