### PR TITLE
ci: build and test on pull requests; fix CLI version check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,132 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# A new push supersedes an in-flight run for the same ref.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  linux:
+    name: Linux (x86_64)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # The build unpacks several Electron trees; the stock runner image leaves
+      # too little room for all five packages at once.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /usr/local/share/boost "$AGENT_TOOLSDIRECTORY"
+          df -h /
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+        env:
+          DISABLE_FLAKEHUB: "true"
+        with:
+          flakehub: false
+          extra-conf: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - name: Setup Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Flake check
+        run: nix flake check --print-build-logs
+
+      # Evaluates the Darwin derivations from Linux. Cheap, and it catches
+      # packaging mistakes in the Darwin branch of pkgs/package.nix that no
+      # Linux build would ever touch.
+      - name: Evaluate Darwin derivations
+        run: |
+          for system in aarch64-darwin x86_64-darwin; do
+            for pkg in default google-antigravity-ide google-antigravity-cli; do
+              echo "==> $system.$pkg"
+              nix eval --raw ".#packages.$system.$pkg.drvPath"
+              echo
+            done
+          done
+
+      - name: Integration test (builds all packages, smoke-checks binaries)
+        run: node scripts/test.mjs --nocolor
+
+  darwin:
+    name: macOS (aarch64)
+    runs-on: macos-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@main
+        env:
+          DISABLE_FLAKEHUB: "true"
+        with:
+          flakehub: false
+          extra-conf: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - name: Setup Nix cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Flake check
+        run: nix flake check --print-build-logs
+
+      # The Darwin path unpacks an APFS .dmg with 7zz, locates the .app bundle
+      # and ad-hoc re-signs it. None of that is reachable from a Linux runner,
+      # so build it here.
+      - name: Build packages
+        run: |
+          nix build .#default .#google-antigravity-ide .#google-antigravity-cli \
+            --no-link --print-build-logs
+
+      # Guards the failure this package has actually hit: the .app sits at the
+      # top level of one DMG but inside a volume-named subfolder in the other,
+      # so a change to the bundle lookup can silently install nothing.
+      - name: Verify the .app bundles were installed
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for attr in default google-antigravity-ide; do
+            out=$(nix build ".#$attr" --no-link --print-out-paths)
+            echo "==> $attr -> $out"
+            apps=( "$out"/Applications/*.app )
+            if [ ${#apps[@]} -ne 1 ]; then
+              echo "error: expected exactly one .app in $out/Applications, found ${#apps[@]}" >&2
+              ls -la "$out/Applications" >&2 || true
+              exit 1
+            fi
+            app="${apps[0]}"
+            exe=""
+            for f in "$app"/Contents/MacOS/*; do
+              if [ -f "$f" ] && [ -x "$f" ]; then exe="$f"; break; fi
+            done
+            if [ -z "$exe" ]; then
+              echo "error: no executable in $app/Contents/MacOS" >&2
+              exit 1
+            fi
+            echo "ok: $app ($(basename "$exe"))"
+            # Informational only. The package ad-hoc re-signs the main
+            # executable but leaves the vendor's _CodeSignature in place, so a
+            # strict bundle verification is not a meaningful gate here.
+            codesign -dv "$exe" 2>&1 || true
+          done
+
+      - name: Verify the CLI runs
+        run: |
+          set -euo pipefail
+          cli=$(nix build .#google-antigravity-cli --no-link --print-out-paths)
+          "$cli/bin/agy" --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # The build unpacks several Electron trees; the stock runner image leaves
-      # too little room for all five packages at once.
-      - name: Free disk space
-        run: |
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
-                      /usr/local/share/boost "$AGENT_TOOLSDIRECTORY"
-          df -h /
-
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
         env:

--- a/scripts/test.mjs
+++ b/scripts/test.mjs
@@ -56,11 +56,14 @@ const builds = [
   { name: 'CLI',              attr: 'google-antigravity-cli',         outLink: 'result-test-cli',        bin: 'bin/agy' },
 ];
 
+// The download URL carries "<semver>-<build id>" (e.g. 1.1.26-5550154686791680),
+// but `agy --version` prints the semver alone. Assert on that part and keep the
+// build id only for reporting.
 function expectedCliVersion() {
   const versions = JSON.parse(fs.readFileSync(path.join(repoRoot, 'artifacts/versions.json'), 'utf8'));
   const url = versions['Antigravity CLI']?.['x86_64-linux']?.url ?? '';
-  const m = url.match(/\/([0-9]+\.[0-9]+\.[0-9]+-[0-9]+)\//);
-  return m ? m[1] : null;
+  const m = url.match(/\/([0-9]+\.[0-9]+\.[0-9]+)-([0-9]+)\//);
+  return m ? { semver: m[1], full: `${m[1]}-${m[2]}` } : null;
 }
 
 async function main() {
@@ -81,10 +84,10 @@ async function main() {
     const expected = expectedCliVersion();
     const versionOut = await runVerify(`${cliBin} --version`);
     console.log(versionOut);
-    if (expected && !versionOut.includes(expected)) {
-      throw new Error(`CLI --version "${versionOut}" does not contain expected version "${expected}"`);
+    if (expected && !versionOut.includes(expected.semver)) {
+      throw new Error(`CLI --version "${versionOut}" does not contain expected version "${expected.semver}" (packaged build ${expected.full})`);
     }
-    logSuccess(`CLI --version reports the packaged version (${expected ?? 'unknown'}).`);
+    logSuccess(`CLI --version reports the packaged version (${expected ? expected.full : 'unknown'}).`);
     await runVerify(`${cliBin} changelog`);
     logSuccess('CLI `changelog` ran successfully.');
 


### PR DESCRIPTION
Follow-up to #91 and #97.

## `scripts/test.mjs` fails on master

`agy --version` prints only the semantic version (`1.1.26`), but the check asserted the full `<semver>-<build id>` string taken from the download URL (`1.1.26-5550154686791680`). The documented local test therefore failed for everyone, on a package that is actually correct. Same class as 26c43c2, where the app's `--version` stopped reporting a version at all.

Now asserts the semver and keeps the build id in the log line, so a real version mismatch still fails while the build id stays visible for diagnosis.

## No CI on pull requests

Only `master`-triggered workflows existed, so PRs showed an empty check rollup. #91 and #97 both sat for weeks on manual verification alone, and #97 shipped an `ALSA_PLUGIN_DIR` wrapper change that reached only the non-default `-no-fhs` variant — a build would have surfaced that immediately.

**Linux job** — flake check, evaluate the Darwin derivations, then `scripts/test.mjs` for the full build and binary smoke check. Evaluating Darwin from Linux is cheap and catches mistakes in the Darwin branch of `pkgs/package.nix` that no Linux build touches.

**macOS job** — flake check and a real build. The Darwin path unpacks an APFS `.dmg` with `7zz`, locates the `.app` bundle and ad-hoc re-signs it. None of that is reachable from a Linux runner, which is exactly why #91 had no coverage at all.

The bundle assertion guards a real difference between the two DMGs: the Base App's `.app` sits at the top level, the IDE's inside a volume-named subfolder. A regression in the lookup can install nothing, silently.

Codesign output is informational rather than a gate. The package ad-hoc re-signs the main executable but leaves the vendor's `_CodeSignature` in place, so a strict bundle verification would not be a meaningful check.

## Verification

- `node scripts/test.mjs` passes end to end: all five packages build, every binary present, CLI version check green.
- `actionlint` clean on the new workflow.
- The macOS bundle-lookup shell logic tested against a mock bundle, including a name containing a space.
- The macOS job itself is unrun until this PR triggers it — it is the first thing the new workflow will exercise.

## Note

`master` has no branch protection, so these checks will run but will not *block* a merge, and `gh pr merge --auto` in the auto-update workflow still merges without waiting for them. Making them required is a repo setting, not a file change — happy to follow up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KA7o52x26DQtFqJ4JHX1Rf